### PR TITLE
增加获取apk版本号功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ import {
 【 Android 】
 
 ```Java
+// 可通过NativeModules.upgrade.versionName获取apk版本号和远程版本号进行比较
 Http.get(Api.api_checkupdate, null, false, (result)=>{  
     if(result.ok) {  
         // 下载最新Apk  
-        NativeModules.upgrade.upgrade(this.state.apkUrl);  
+        NativeModules.upgrade.upgrade(this.state.apkUrl);
     }  
 });  
 ```

--- a/android_upgrade/UpgradeModule.java
+++ b/android_upgrade/UpgradeModule.java
@@ -1,12 +1,15 @@
-package com.d3o.android_upgrade;
+package io.cxjky.taskApp.android_upgrade;
 
 import android.content.Context;
-
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import java.util.HashMap;
+import java.util.Map;
 /**
  * Created by Song on 2017/7/10.
  */
@@ -14,10 +17,20 @@ public class UpgradeModule extends ReactContextBaseJavaModule {
 
     private static ReactApplicationContext context;
     private static final String EVENT_NAME = "LOAD_PROGRESS";
+    private String versionName = "1.0.0";
+    private int versionCode = 1;
 
     public UpgradeModule(ReactApplicationContext reactContext) {
         super(reactContext);
+        PackageInfo pInfo = null;
         this.context = reactContext;
+        try {
+            pInfo = reactContext.getPackageManager().getPackageInfo(reactContext.getPackageName(), 0);
+            versionName = pInfo.versionName;
+            versionCode = pInfo.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -25,11 +38,19 @@ public class UpgradeModule extends ReactContextBaseJavaModule {
         return "upgrade";
     }
 
+    @Override
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+        constants.put("versionName", versionName);
+        constants.put("versionCode", versionCode);
+        return constants;
+    }
+
     @ReactMethod
     public void upgrade(String apkUrl) {
         UpdateDialog.goToDownload(context, apkUrl);
     }
-    
+
     public static void sendProgress(int msg) {
         context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(EVENT_NAME, msg);

--- a/android_upgrade/UpgradeModule.java
+++ b/android_upgrade/UpgradeModule.java
@@ -1,4 +1,4 @@
-package io.cxjky.taskApp.android_upgrade;
+package com.d3o.android_upgrade;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;


### PR DESCRIPTION
修改了android_upgrade/UpgradeModule.java，可通过NativeModules.upgrade.versionName获取apk版本号和远程版本号进行比较，不然你的Api.api_checkupdate会让人看得云里雾里。