### PR TITLE
修复 下载过程中不断响铃的问题

### DIFF
--- a/android_upgrade/DownloadService.java
+++ b/android_upgrade/DownloadService.java
@@ -41,7 +41,7 @@ public class DownloadService extends IntentService {
         
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             mBuilder = new Builder(this, "downLoadChannelId");
-            NotificationChannel channel = new NotificationChannel("downLoadChannelId", "downLoadChannel", NotificationManager.IMPORTANCE_HIGH);
+            NotificationChannel channel = new NotificationChannel("downLoadChannelId", "downLoadChannel", NotificationManager.IMPORTANCE_LOW);
             mNotifyManager.createNotificationChannel(channel);
         } else {
             mBuilder = new Builder(this);


### PR DESCRIPTION
IMPORTANCE_LOW重要性级别设置 设置为高 默认会不断响铃 或震动体验极差，所以这里默认设置为低就会安静地下载