### PR TITLE
Global appstore

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,12 +111,15 @@ export const downloadApk = async ({
         .catch((errorMessage, statusCode) => {
           callback?.onFailure(errorMessage, statusCode);
         });
-    callback?.onComplete();
-    if (downloadInstall) {
-        const apkFileExist = await checkApkFileExist(apkFilePath);
-        apkFileExist && RNUpgrade.installApk(apkFilePath);
+
+    const apkFileExist = await checkApkFileExist(apkFilePath);
+    if (downloadInstall && apkFileExist) {
+        RNUpgrade.installApk(apkFilePath);
     }
+    callback?.onComplete(apkFileExist ? apkFilePath : null);
 }
+
+export const installApk = RNUpgrade.installApk;
 
 /**
  * 检查本地是否有apk文件

--- a/ios_upgrade/upgrade.m
+++ b/ios_upgrade/upgrade.m
@@ -83,7 +83,7 @@ RCT_EXPORT_METHOD(upgrade:(NSString *)storeappID callback:(RCTResponseSenderBloc
 }
 RCT_EXPORT_METHOD(openAPPStore:(NSString *)storeappID ){
   //此处加入应用在app store的地址，方便用户去更新，一种实现方式如下
-  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/us/app/id%@?ls=1&mt=8", storeappID]];
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/app/id%@?ls=1&mt=8", storeappID]];
   [[UIApplication sharedApplication] openURL:url];
 
 }


### PR DESCRIPTION
Removing the `us` from the iTunes URL allow to always open the proper app regardless on the language. This also remove the needs to specify a lang parameter to the `openAPPStore` function. 