### PR TITLE
Allow to install apk by hand

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,12 +111,15 @@ export const downloadApk = async ({
         .catch((errorMessage, statusCode) => {
           callback?.onFailure(errorMessage, statusCode);
         });
-    callback?.onComplete();
-    if (downloadInstall) {
-        const apkFileExist = await checkApkFileExist(apkFilePath);
-        apkFileExist && RNUpgrade.installApk(apkFilePath);
+
+    const apkFileExist = await checkApkFileExist(apkFilePath);
+    if (downloadInstall && apkFileExist) {
+        RNUpgrade.installApk(apkFilePath);
     }
+    callback?.onComplete(apkFileExist ? apkFilePath : null);
 }
+
+export const installApk = RNUpgrade.installApk;
 
 /**
  * 检查本地是否有apk文件


### PR DESCRIPTION
The PR allow to get the apk local file name as argument in the `onComplete` callback and eventually call `installApk` at some point since it's exported to the outside world. This enable interesting behaviours which may be preferable in most cases.